### PR TITLE
ci: point the code job at repobuddy/.github

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-verify.yml@v2
     with:
       os: '["ubuntu-latest"]'
       node-version: '[24]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ on:
     - created
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-verify.yml@v2
     with:
       os: '["ubuntu-latest"]'
       node-version: '[24]'
@@ -76,5 +76,5 @@ jobs:
         VSCE_PAT: ${{ secrets.VSCE_PAT }}
         OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
   # docgen:
-  #     uses: unional/.github/.github/workflows/pnpm-docs.yml@main
+  #     uses: repobuddy/.github/.github/workflows/pnpm-docs.yml@v2
   #     needs: release


### PR DESCRIPTION
Transferred into `repobuddy` on 2026-09-02, but `pull-request.yml` and `release.yml` still called `unional/.github/.github/workflows/pnpm-verify.yml@main` — a personal namespace at a floating branch ref.

Only the `code` job changes. This repo's `release` job is a local `vsce` job publishing to the VS Code marketplace, not a reusable workflow, and is untouched.

## Safety checks

**Inputs preserved.** The caller passes `os` and `node-version`; both exist in repobuddy's `pnpm-verify.yml` with the same meaning, so the existing `["ubuntu-latest"]` / `[24]` pin carries over unchanged.

**Job id preserved.** Still `code`, so `code / all-checks` still exists.

**`@main` → `@v2`**, so an upstream change can no longer land here unreviewed.

## Note on the marketplace publisher

The transfer does **not** move the VS Code marketplace publisher, which remains `unional`. That is a separate namespace from the GitHub org and needs no action for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETjy9oQGyETyFmDBdR9Egz