### PR TITLE
fix: point repository metadata at repobuddy/vscode-sort-package-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
 	"categories": [
 		"Other"
 	],
-	"homepage": "https://github.com/unional/vscode-sort-package-json#readme",
+	"homepage": "https://github.com/repobuddy/vscode-sort-package-json#readme",
 	"bugs": {
-		"url": "https://github.com/unional/vscode-sort-package-json/issues"
+		"url": "https://github.com/repobuddy/vscode-sort-package-json/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/unional/vscode-sort-package-json.git"
+		"url": "git+https://github.com/repobuddy/vscode-sort-package-json.git"
 	},
 	"license": "MIT",
 	"publisher": "unional",


### PR DESCRIPTION
The 2026-09-02 org transfer moved this repo but left `package.json` naming its old owner. **npm verifies the provenance bundle against `repository.url` at publish time**, so the next release fails with:

```
E422 Unprocessable Entity - PUT https://registry.npmjs.org/<pkg>
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "https://github.com/<old-owner>/<repo>.git",
expected to match "https://github.com/<new-owner>/<repo>" from provenance
```

## How this was found

`jest-watch-suspend`'s first post-transfer release run hit it. Its trusted publisher had already been re-registered correctly, so the error moved on from `E404` (wrong publisher) to `E422` (wrong metadata) — **a second fault hiding behind the first**. An audit then found every one of the 14 transferred repos carries the same stale URL.

Nothing warns you: the old GitHub path keeps resolving through the rename/transfer redirect, so the value looks valid right up until a publish verifies it against the OIDC claim.

## Scope

`package.json` metadata (`repository`, `bugs`, `homepage`) plus README links pointing at this repo's own old path.

**`CHANGELOG.md` is deliberately untouched** — those are historical release records and their commit/compare links still resolve through the redirect. Rewriting them would be noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETjy9oQGyETyFmDBdR9Egz