### PR TITLE
chore: enforce the 24h supply-chain soak

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,22 @@ ignoredBuiltDependencies:
 onlyBuiltDependencies:
   - '@vscode/vsce-sign'
   - esbuild
+
+# Supply-chain soak: no dependency may be installed until it has been on the registry
+# for 24h. This is the control that stops a compromised release from being pulled into
+# a build within hours of publication.
+#
+# It must live here. In `.npmrc`, `minimumreleaseage` is not a valid key - it never
+# reaches pnpm's typed config and the soak is silently inert.
+#
+# `minimumReleaseAgeStrict` is required for it to mean anything. Without it pnpm runs
+# LOOSE: a too-young package is not rejected, it is appended to
+# `minimumReleaseAgeExclude` and installed anyway, so the soak excuses itself on every
+# install and the waiver list grows on its own. Strict turns that into a hard
+# ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION.
+#
+# There is deliberately no exclusion list. If an install trips the gate, prefer waiting
+# it out or pinning an older mature version; an exclusion is a dated exception that
+# should carry its reason and the date it becomes removable.
+minimumReleaseAge: 1440 # 1 day
+minimumReleaseAgeStrict: true


### PR DESCRIPTION
Found by the fleet-wide dead-control audit, which checked all 74 pnpm-workspace repos across `unional`, `cyberuni`, `repobuddy` and `justland`. This repo had **no `minimumReleaseAge` at all**, so nothing held back a freshly-published version of any dependency, direct or transitive.

This is not a new policy — `minimumReleaseAge: 1440` is what ~30 repos in the fleet already carry. This one was simply missing it.

## The window existed, in the one place it does nothing

`.npmrc` carried `minimumreleaseage`. That is **not a valid npm or pnpm key** — it never reaches pnpm's typed config, so `pnpm config get minimumReleaseAge` returned `undefined` and no version was ever held back. The line is **removed rather than corrected**: leaving a second, non-functional home for the setting is what hid this in the first place.

## Both settings, because one without the other does nothing

`minimumReleaseAgeStrict` is set alongside the window. Without it pnpm runs **loose**: a too-young package is not rejected, it is appended to `minimumReleaseAgeExclude` and installed anyway — so the soak excuses itself on every install and the waiver list grows without anyone deciding to add to it.

No exclusion list is added. The install resolves cleanly under the gate.

## Verified

```
pnpm config get minimumReleaseAge        -> 1440
pnpm config get minimumReleaseAgeStrict  -> true
pnpm install --frozen-lockfile           -> resolves, no lockfile change
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETjy9oQGyETyFmDBdR9Egz