### PR TITLE
fix: move pnpm.overrides to pnpm-workspace.yaml before the next pnpm major

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,17 +77,6 @@
 		"typescript": "^5.8.3",
 		"vitest": "^5.0.0"
 	},
-	"pnpm": {
-		"overrides": {
-			"brace-expansion@<1.1.13": ">=1.1.13",
-			"brace-expansion@>=2.0.0 <2.0.3": ">=2.0.3",
-			"diff@>=6.0.0 <8.0.3": ">=8.0.3",
-			"lodash-es@<=4.17.23": ">=4.18.0",
-			"markdown-it@>=13.0.0 <14.1.1": ">=14.1.1",
-			"serialize-javascript@<7.0.5": ">=7.0.5",
-			"underscore@<=1.13.7": ">=1.13.8"
-		}
-	},
 	"packageManager": "pnpm@10.34.5",
 	"engines": {
 		"vscode": "^1.90.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,17 @@ onlyBuiltDependencies:
 # should carry its reason and the date it becomes removable.
 minimumReleaseAge: 1440 # 1 day
 minimumReleaseAgeStrict: true
+
+# Security floors for transitive dependencies (GHSA advisories). These lived in
+# `package.json` under `pnpm.overrides`. pnpm 10 still reads that key, but pnpm 11
+# does not - it warns `The "pnpm" field in package.json is no longer read by pnpm`
+# and ignores it, which would silently drop every pin below the moment this repo takes
+# a pnpm major. Declared here they apply on both.
+overrides:
+  'brace-expansion@<1.1.13': '>=1.1.13'
+  'brace-expansion@>=2.0.0 <2.0.3': '>=2.0.3'
+  'diff@>=6.0.0 <8.0.3': '>=8.0.3'
+  'lodash-es@<=4.17.23': '>=4.18.0'
+  'markdown-it@>=13.0.0 <14.1.1': '>=14.1.1'
+  'serialize-javascript@<7.0.5': '>=7.0.5'
+  'underscore@<=1.13.7': '>=1.13.8'


### PR DESCRIPTION
**Nothing is broken today.** This is a preventive move, and the window closes on the next pnpm major.

Seven security floors — GHSA advisories for `brace-expansion`, `diff`, `lodash-es`, `markdown-it`, `serialize-javascript` and `underscore` — are declared in `package.json` under `pnpm.overrides`. **pnpm 10 reads that key**, so they apply now; the lockfile records all seven.

**pnpm 11 does not.** It warns and ignores the key:

```
The "pnpm" field in package.json is no longer read by pnpm.
The following keys were ignored: "pnpm.overrides"
```

So the moment this repo takes a pnpm major, all seven pins go dead. Nothing fails, nothing turns red — the advisory versions just come back.

## Already happened elsewhere

`repobuddy/vis-bot` is on pnpm 11 with exactly this shape. Its lockfile carried **`picomatch@2.3.2`, `minimatch@3.1.5`/`5.1.9`, `undici@5.29.0`/`6.25.0`** — three of four pins below their own floors, silently. Fixed in repobuddy/vis-bot#61.

There is an open `renovate/pnpm-*` PR against this repo, so it is a question of when.

## The change is provably inert today

Values move verbatim to `overrides:` in `pnpm-workspace.yaml`, which pnpm reads on **both** 10 and 11. No floor is changed.

Verified under this repo's own pinned pnpm (`10.34.5`, via corepack):

```
pnpm install      ->  exit 0
git status        ->  package.json, pnpm-workspace.yaml   (pnpm-lock.yaml UNCHANGED)
pnpm run verify   ->  exit 0, 1 passed (1)
```

An unchanged lockfile is the point: identical resolution, future-proof location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETjy9oQGyETyFmDBdR9Egz